### PR TITLE
Install `tslib` as dependency

### DIFF
--- a/packages/js-auth/package.json
+++ b/packages/js-auth/package.json
@@ -44,6 +44,9 @@
     "access": "public"
   },
   "license": "MIT",
+  "dependencies": {
+    "tslib": "^2.6.2"
+  },
   "devDependencies": {
     "@types/node": "^20.11.16",
     "@vitejs/plugin-react": "^4.2.1",
@@ -51,7 +54,6 @@
     "jsdom": "^24.0.0",
     "minimize-js": "^1.4.0",
     "tsc-alias": "^1.8.8",
-    "tslib": "^2.6.2",
     "typescript": "^5.3.3",
     "vite": "^5.1.0",
     "vite-tsconfig-paths": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,10 @@ importers:
         version: 5.3.3
 
   packages/js-auth:
+    dependencies:
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
     devDependencies:
       '@types/node':
         specifier: ^20.11.16
@@ -41,9 +45,6 @@ importers:
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
-      tslib:
-        specifier: ^2.6.2
-        version: 2.6.2
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -6729,7 +6730,6 @@ packages:
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
-    dev: true
 
   /tuf-js@1.1.7:
     resolution: {integrity: sha512-i3P9Kgw3ytjELUfpuKVDNBJvk4u5bXL6gskv572mcevPbSKCV3zt3djhmlEQ65yERjIbOSncy7U4cQJaB1CBCg==}


### PR DESCRIPTION
## Context

When `js-auth` is used in a blank project, we get this error.

<img width="1045" alt="tslib error" src="https://github.com/commercelayer/commercelayer-js-auth/assets/1681269/488dee0b-4201-4163-a8eb-a395e2a3a0b9">

## What I did

I moved the module `tslib` from `devDependencies` section to the `dependencies` section.

As stated [here](https://www.typescriptlang.org/tsconfig#importHelpers) we need to ensure that the `tslib` module is able to be imported at runtime.

> If the `importHelpers` flag is on, these helper functions are instead imported from the [tslib](https://www.npmjs.com/package/tslib) module. You will need to ensure that the `tslib` module is able to be imported at runtime. This only affects modules; global script files will not attempt to import modules.
