### PR TITLE
Allow authentication to passthrough headers

### DIFF
--- a/packages/js-auth/package.json
+++ b/packages/js-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commercelayer/js-auth",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Commerce Layer Javascript Auth",
   "repository": {
     "url": "https://github.com/commercelayer/commercelayer-js-auth.git"

--- a/packages/js-auth/specs/provisioning.spec.ts
+++ b/packages/js-auth/specs/provisioning.spec.ts
@@ -11,7 +11,25 @@ describe('Provisioning', () => {
       clientId,
       clientSecret
     })
-   
+
+    expect(res).toHaveProperty('accessToken')
+    expect(res).toHaveProperty('tokenType')
+    expect(res).toHaveProperty('expiresIn')
+    expect(res).toHaveProperty('scope')
+    expect(res).toHaveProperty('createdAt')
+    expect(res).toHaveProperty('expires')
+    expect(res.expires).toBeInstanceOf(Date)
+    expect(res.expires.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('Can passthrough headers when provisiong a token', async () => {
+    const headers = { 'Forwarded': 'for=unknown;by:127.0.0.1' }
+    const res = await provisioning.authentication({
+      domain,
+      clientId,
+      clientSecret,
+      headers
+    })
     expect(res).toHaveProperty('accessToken')
     expect(res).toHaveProperty('tokenType')
     expect(res).toHaveProperty('expiresIn')

--- a/packages/js-auth/src/provisioning.ts
+++ b/packages/js-auth/src/provisioning.ts
@@ -13,6 +13,7 @@ export interface TokenJson {
 
 async function authentication({
   domain = 'commercelayer.io',
+  headers = {},
   ...options
 }: TProvisioningOptions): Promise<TProvisioningReturn> {
   const attributes = {
@@ -30,6 +31,7 @@ async function authentication({
   return await fetch(`https://auth.${domain}/oauth/token`, {
     method: 'POST',
     headers: {
+      ...headers,
       'Content-Type': 'application/vnd.api+json',
       Accept: 'application/vnd.api+json'
     },

--- a/packages/js-auth/src/types/index.ts
+++ b/packages/js-auth/src/types/index.ts
@@ -32,6 +32,10 @@ export interface TBaseOptions {
    * The Commerce Layer's domain.
    */
   domain?: string
+  /**
+   * Additional headers to set on requests.
+   */
+  headers?: HeadersInit
 }
 
 export type TOptions<TGrantType> = TGrantType extends 'password'


### PR DESCRIPTION

## What I did

Hi there, I have been working on a Commerce Layer project and the need arose to pass along a selection of headers during authentication.

This PR adds a `headers` field to `authentication()`'s `TBaseOptions` matching the input type (`HeadersInit` of the underlying `fetch` call. 

* `headers` is optional (may be `undefined`)
* `headers` are spread _before_ the SDK's headers to give them precedence (`Content-Type` & `Accept`)

## How to test

* I have added a test case to `provisioning.spec.ts`–between the two cases demonstrating an `authentication` call succeeds with headers present or absent.

## Checklist

> I did have some trouble running test suite on account of a `failed to load config from .../packages/js-auth/vitest.config.ts`

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.

_Please let me know if you'd like the version bump removed. I happened to be using it in testing this locally._