### PR TITLE
Add `revoke` method

### DIFF
--- a/packages/js-auth/README.md
+++ b/packages/js-auth/README.md
@@ -18,6 +18,7 @@ A JavaScript Library wrapper that helps you use the Commerce Layer API for [Auth
   - [Webapp application with authorization code flow](#webapp-authorization-code)
   - [Provisioning application](#provisioning)
   - [JWT bearer](#jwt-bearer)
+  - [Revoking a token](#revoking-a-token)
 - [Utilities](#utilities)
   - [Decode an access token](#decode-an-access-token)
 - [Contributors guide](#contributors-guide)
@@ -248,6 +249,20 @@ const auth = await authenticate('urn:ietf:params:oauth:grant-type:jwt-bearer', {
 
 console.log('My access token: ', auth.accessToken)
 console.log('Expiration date: ', auth.expires)
+```
+
+### Revoking a token
+
+Any previously generated access tokens (refresh tokens included) can be [revoked](https://docs.commercelayer.io/core/authentication/revoking-a-token) before their natural expiration date.
+
+```ts
+import { revoke } from '@commercelayer/js-auth'
+
+await revoke({
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  token: 'a-generated-access-token'
+})
 ```
 
 ## Utilities

--- a/packages/js-auth/src/index.ts
+++ b/packages/js-auth/src/index.ts
@@ -1,11 +1,12 @@
 export { authenticate } from './authenticate.js'
+export { revoke } from './revoke.js'
 
 export {
   jwtDecode,
   jwtIsDashboard,
   jwtIsIntegration,
-  jwtIsUser,
   jwtIsSalesChannel,
+  jwtIsUser,
   jwtIsWebApp
 } from './jwtDecode.js'
 
@@ -14,5 +15,7 @@ export { createAssertion } from './jwtEncode.js'
 export type {
   AuthenticateOptions,
   AuthenticateReturn,
-  GrantType
+  GrantType,
+  RevokeOptions,
+  RevokeReturn
 } from './types/index.js'

--- a/packages/js-auth/src/revoke.spec.ts
+++ b/packages/js-auth/src/revoke.spec.ts
@@ -1,0 +1,44 @@
+import { authenticate, revoke } from './index.js'
+
+const integrationClientId = process.env.VITE_TEST_INTEGRATION_CLIENT_ID
+const clientSecret = process.env.VITE_TEST_CLIENT_SECRET
+const domain = process.env.VITE_TEST_DOMAIN
+
+describe('Revoke', () => {
+  it('should be able to revoke a valid integration accessToken', async () => {
+    const authenticateResponse = await authenticate('client_credentials', {
+      clientId: integrationClientId,
+      clientSecret,
+      domain
+    })
+
+    expect(authenticateResponse).toHaveProperty('accessToken')
+
+    const revokeResponse = await revoke({
+      clientId: integrationClientId,
+      clientSecret,
+      token: authenticateResponse.accessToken,
+      domain
+    })
+
+    expect(revokeResponse).toStrictEqual({})
+  })
+
+  it('should respond with error when something goes wrong', async () => {
+    // @ts-expect-error I need to test this scenario
+    const revokeResponse = await revoke({
+      clientSecret,
+      token: '1234',
+      domain
+    })
+
+    expect(revokeResponse).toHaveProperty('errors')
+    expect(revokeResponse.errors).toBeInstanceOf(Array)
+    expect(revokeResponse.errors?.[0]).toMatchObject({
+      code: 'FORBIDDEN',
+      detail: 'You are not authorized to revoke this token',
+      status: 403,
+      title: 'unauthorized_client'
+    })
+  })
+})

--- a/packages/js-auth/src/revoke.ts
+++ b/packages/js-auth/src/revoke.ts
@@ -1,0 +1,22 @@
+import type { RevokeOptions, RevokeReturn } from '#types/index.js'
+
+import { camelCaseToSnakeCase } from '#utils/camelCaseToSnakeCase.js'
+import { mapKeys } from '#utils/mapKeys.js'
+
+export async function revoke({
+  domain = 'commercelayer.io',
+  ...options
+}: RevokeOptions): Promise<RevokeReturn> {
+  const body = mapKeys(options, camelCaseToSnakeCase)
+
+  const response = await fetch(`https://auth.${domain}/oauth/revoke`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+
+  return (await response.json()) as RevokeReturn
+}

--- a/packages/js-auth/src/types/base.ts
+++ b/packages/js-auth/src/types/base.ts
@@ -39,7 +39,7 @@ export interface TBaseOptions {
   }
 }
 
-export interface TBaseReturn {
+export type TBaseReturn = {
   /**
    * The access token.
    */
@@ -64,6 +64,9 @@ export interface TBaseReturn {
    * The creation date of the access token.
    */
   createdAt: number
+} & TError
+
+export interface TError {
   /**
    * The list of errors when something goes wrong.
    */

--- a/packages/js-auth/src/types/index.ts
+++ b/packages/js-auth/src/types/index.ts
@@ -2,11 +2,11 @@ import type {
   TAuthorizationCodeOptions,
   TAuthorizationCodeReturn
 } from './authorizationCode.js'
-import type { TBaseReturn } from './base.js'
+import type { TBaseOptions, TBaseReturn, TError } from './base.js'
 import type { TClientCredentialsOptions } from './clientCredentials.js'
+import type { TJwtBearerOptions, TJwtBearerReturn } from './jwtBearer.js'
 import type { TPasswordOptions, TPasswordReturn } from './password.js'
 import type { TRefreshTokenOptions } from './refreshToken.js'
-import type { TJwtBearerOptions, TJwtBearerReturn } from './jwtBearer.js'
 
 /**
  * The grant type.
@@ -43,3 +43,12 @@ export type AuthenticateReturn<TGrantType extends GrantType> =
           : TGrantType extends 'authorization_code'
             ? TAuthorizationCodeReturn
             : never
+
+export type RevokeOptions = Pick<TBaseOptions, 'clientId' | 'domain'> & {
+  /** Your application's client secret (required for confidential API credentials and non-confidential API credentials without a customer or a user in the JWT only). */
+  clientSecret?: string
+  /** A valid access or refresh token. */
+  token: string
+}
+
+export type RevokeReturn = Pick<TError, 'errors'>


### PR DESCRIPTION
## What I did

I added a `revoke` method.

Any previously generated access tokens (refresh tokens included) can be revoked before their natural expiration date.

```ts
import { revoke } from '@commercelayer/js-auth'

await revoke({
  clientId: 'your-client-id',
  clientSecret: 'your-client-secret',
  token: 'a-generated-access-token'
})
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
