### PR TITLE
Overwrite fetch

### DIFF
--- a/packages/js-auth/src/authenticate.ts
+++ b/packages/js-auth/src/authenticate.ts
@@ -40,6 +40,7 @@ export async function authenticate<TGrantType extends GrantType>(
   {
     domain = 'commercelayer.io',
     headers,
+    fetchFunction = fetch,
     ...options
   }: AuthenticateOptions<TGrantType>
 ): Promise<AuthenticateReturn<TGrantType>> {
@@ -51,7 +52,7 @@ export async function authenticate<TGrantType extends GrantType>(
     camelCaseToSnakeCase
   )
 
-  const response = await fetch(`https://auth.${domain}/oauth/token`, {
+  const response = await fetchFunction(`https://auth.${domain}/oauth/token`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/js-auth/src/types/base.ts
+++ b/packages/js-auth/src/types/base.ts
@@ -36,7 +36,12 @@ export interface TBaseOptions {
      * Header values should be strings, or `undefined` if the header is not set.
      */
     [key: string]: string | undefined
-  }
+  },
+  /**
+   * An optional implementation of fetch, to overwrite the default fetch implementation.
+   * Defaults to the standard implementation of fetch in Node.
+   */
+  fetchFunction?: typeof fetch;
 }
 
 export type TBaseReturn = {


### PR DESCRIPTION
## What I did

This PR introduces the ability to overwrite the implementation of `fetch` for all functions that do use `fetch`. It introduces no new dependencies, so keeps the bundle as small as possible, while giving future users more flexibility in how they approach caching tokens from the `kid` endpoint, for example. It also allows users to add middleware to their fetch, including logging middleware, to get a better idea of what happens in communication between their app and the CommerceLayer authentication endpoints.

A simple example of an implementation around this, would be:

```ts
import {jwtVerify} from "../../packages/js-auth/src";

type FetchArgs = Parameters<typeof fetch>;
type VerifyOptions = Parameters<typeof jwtVerify>;

// Cache implementation where force-cache is always set on each request.
const cachedFetch = (...[input, init]: FetchArgs) => {
  return fetch(
    input,
    {
      ...init,
      cache: "force-cache"
    }
  )
}

// If you want to reuse the function, you can wrap it, like so:
const verifyJwt = (...[token, options]: VerifyOptions) => jwtVerify(token, { ...options, fetchFunction: cachedFetch });

// This function grabs the jwt with the potentially force-cached data from fetch.
async function getPayload(token: string) {
  const jwt = await verifyJwt(token);
  return jwt.payload;
}
```

## How to test

Run the above code snippet locally to see it in action.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
