### PR TITLE
`jwtVerify` extracts the `iss` in the right way

### DIFF
--- a/packages/js-auth/src/getCoreApiBaseEndpoint.ts
+++ b/packages/js-auth/src/getCoreApiBaseEndpoint.ts
@@ -1,5 +1,6 @@
 import { InvalidTokenError } from './errors/InvalidTokenError.js'
 import { jwtDecode } from './jwtDecode.js'
+import { extractIssuer } from './utils/extractIssuer.js'
 
 /**
  * Derive the [Core API base endpoint](https://docs.commercelayer.io/core/api-specification#base-endpoint) given a valid access token.
@@ -19,10 +20,8 @@ export function getCoreApiBaseEndpoint(accessToken: string): string {
     throw new InvalidTokenError('Invalid token format')
   }
 
-  return decodedJWT?.payload?.iss?.startsWith('https://auth.')
-    ? decodedJWT.payload.iss.replace(
-        'auth',
-        decodedJWT.payload.organization.slug
-      )
-    : `https://${decodedJWT.payload.organization.slug}.commercelayer.io`
+  return extractIssuer(decodedJWT).replace(
+    'auth',
+    decodedJWT.payload.organization.slug
+  )
 }

--- a/packages/js-auth/src/jwtVerify.ts
+++ b/packages/js-auth/src/jwtVerify.ts
@@ -3,6 +3,7 @@ import { TokenError } from './errors/TokenError.js'
 import { TokenExpiredError } from './errors/TokenExpiredError.js'
 import { jwtDecode, type CommerceLayerJWT } from './jwtDecode.js'
 import { decodeBase64URLSafe } from './utils/base64.js'
+import { extractIssuer } from './utils/extractIssuer.js'
 
 /**
  * Verify a Commerce Layer access token.
@@ -111,7 +112,7 @@ async function getJsonWebKey(
 async function getJsonWebKeys(
   jwt: CommerceLayerJWT
 ): Promise<CommerceLayerJsonWebKey[]> {
-  const jwksUrl = `${jwt.payload.iss}/.well-known/jwks.json`
+  const jwksUrl = `${extractIssuer(jwt)}/.well-known/jwks.json`
 
   const response = await fetch(jwksUrl).then<{
     keys: CommerceLayerJsonWebKey[] | undefined

--- a/packages/js-auth/src/revoke.ts
+++ b/packages/js-auth/src/revoke.ts
@@ -2,6 +2,7 @@ import { jwtDecode } from './jwtDecode.js'
 import type { RevokeOptions, RevokeReturn } from './types/index.js'
 
 import { camelCaseToSnakeCase } from './utils/camelCaseToSnakeCase.js'
+import { extractIssuer } from './utils/extractIssuer.js'
 import { mapKeys } from './utils/mapKeys.js'
 
 /**
@@ -21,11 +22,9 @@ import { mapKeys } from './utils/mapKeys.js'
 export async function revoke(options: RevokeOptions): Promise<RevokeReturn> {
   const body = mapKeys(options, camelCaseToSnakeCase)
   const decodedJWT = jwtDecode(options.token)
-  const iss = decodedJWT?.payload?.iss?.startsWith('https://auth.')
-    ? decodedJWT.payload.iss
-    : 'https://auth.commercelayer.io'
+  const issuer = extractIssuer(decodedJWT)
 
-  const response = await fetch(`${iss}/oauth/revoke`, {
+  const response = await fetch(`${issuer}/oauth/revoke`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/js-auth/src/utils/extractIssuer.spec.ts
+++ b/packages/js-auth/src/utils/extractIssuer.spec.ts
@@ -1,0 +1,43 @@
+import { extractIssuer } from './extractIssuer.js'
+
+describe('extractIssuer', () => {
+  it('should be able to extract the issuer from a token without the `iss` key', () => {
+    expect(
+      extractIssuer(
+        // @ts-expect-error I want to test this scenario
+        {}
+      )
+    ).toEqual('https://auth.commercelayer.io')
+  })
+
+  it('should be able to extract the issuer from a token with a wrong `iss` key', () => {
+    expect(
+      extractIssuer({
+        // @ts-expect-error I want to test this scenario
+        payload: {
+          iss: 'https://commercelayer.io'
+        }
+      })
+    ).toEqual('https://auth.commercelayer.io')
+  })
+
+  it('should be able to extract the issuer from a token with a valid `iss` key', () => {
+    expect(
+      extractIssuer({
+        // @ts-expect-error I want to test this scenario
+        payload: {
+          iss: 'https://auth.commercelayer.io'
+        }
+      })
+    ).toEqual('https://auth.commercelayer.io')
+
+    expect(
+      extractIssuer({
+        // @ts-expect-error I want to test this scenario
+        payload: {
+          iss: 'https://auth.commercelayer.co'
+        }
+      })
+    ).toEqual('https://auth.commercelayer.co')
+  })
+})

--- a/packages/js-auth/src/utils/extractIssuer.ts
+++ b/packages/js-auth/src/utils/extractIssuer.ts
@@ -1,0 +1,16 @@
+import type { CommerceLayerJWT } from 'src/jwtDecode.js'
+
+/**
+ * Extract the `iss` from the decoded JWT.
+ *
+ * This is not as simple as `decodedJWT.payload.iss` because:
+ * - at the beginning the `iss` was not required.
+ * - the value can be `https://commercelayer.io` is old tokens.
+ */
+export function extractIssuer(
+  decodedJWT: CommerceLayerJWT
+): `https://auth.${string}` {
+  return decodedJWT?.payload?.iss?.startsWith('https://auth.')
+    ? (decodedJWT.payload.iss as `https://auth.${string}`)
+    : 'https://auth.commercelayer.io'
+}


### PR DESCRIPTION
## What I did

I created an `extractIssuer` helper that handle all scenarios and helps `jwtVerify` to get the right `iss`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
