### PR TITLE
Standardize error handling: always return array in `response.errors`

### DIFF
--- a/packages/js-auth/src/authenticate.spec.ts
+++ b/packages/js-auth/src/authenticate.spec.ts
@@ -1,4 +1,9 @@
-import { authenticate, createAssertion, jwtDecode } from "./index.js"
+import { autoRetryOnError429 } from "vitest.utility.js"
+import {
+  createAssertion,
+  jwtDecode,
+  authenticate as originalAuthenticate,
+} from "./index.js"
 
 const clientId = process.env.VITE_TEST_SALES_CHANNEL_CLIENT_ID
 const integrationClientId = process.env.VITE_TEST_INTEGRATION_CLIENT_ID
@@ -9,6 +14,8 @@ const storeScope = process.env.VITE_TEST_STORE_SCOPE
 const username = process.env.VITE_TEST_USERNAME
 const password = process.env.VITE_TEST_PASSWORD
 const tokenIss = process.env.VITE_TEST_TOKEN_ISS
+
+const authenticate = autoRetryOnError429(originalAuthenticate)
 
 describe("Organization auth", () => {
   it("should throw an error when the clientId is not valid.", async () => {

--- a/packages/js-auth/src/authenticate.ts
+++ b/packages/js-auth/src/authenticate.ts
@@ -67,6 +67,10 @@ export async function authenticate<TGrantType extends GrantType>(
     json.expires = new Date(Date.now() + json.expires_in * 1000)
   }
 
+  if (json.errors != null && !Array.isArray(json.errors)) {
+    json.errors = [json.errors]
+  }
+
   return mapKeys(
     json,
     snakeCaseToCamelCase,

--- a/packages/js-auth/src/revoke.spec.ts
+++ b/packages/js-auth/src/revoke.spec.ts
@@ -1,5 +1,12 @@
+import { autoRetryOnError429 } from "vitest.utility.js"
 import createFetchMock from "vitest-fetch-mock"
-import { authenticate, revoke } from "./index.js"
+import {
+  authenticate as originalAuthenticate,
+  revoke as originalRevoke,
+} from "./index.js"
+
+const authenticate = autoRetryOnError429(originalAuthenticate)
+const revoke = autoRetryOnError429(originalRevoke)
 
 const fetchMocker = createFetchMock(vi)
 

--- a/packages/js-auth/src/types/base.ts
+++ b/packages/js-auth/src/types/base.ts
@@ -81,7 +81,7 @@ export interface TError {
     code: string
     detail: string
     meta: Record<string, unknown>
-    status: 401
+    status: 400 | 401 | 429 | 500
     title: string
   }>
 }

--- a/packages/js-auth/vitest.config.ts
+++ b/packages/js-auth/vitest.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
     globals: true,
-    testTimeout: 10_000
-  }
+    testTimeout: 120_000,
+  },
 })

--- a/packages/js-auth/vitest.utility.ts
+++ b/packages/js-auth/vitest.utility.ts
@@ -1,0 +1,27 @@
+type GenericMethod = (
+  // biome-ignore lint/suspicious/noExplicitAny: I don't wanna specify args
+  ...args: any[]
+) => Promise<{ errors?: { status: number }[] }>
+
+export const autoRetryOnError429 = <Method extends GenericMethod>(
+  method: Method,
+): Method => {
+  const handler: GenericMethod = async (...args) => {
+    const response = await method(...args)
+
+    if (
+      response.errors != null &&
+      response.errors.find((e) => e.status === 429) != null
+    ) {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(handler(...args))
+        }, 30_000)
+      })
+    }
+
+    return response
+  }
+
+  return handler as Method
+}


### PR DESCRIPTION
## What I did

I added an auto-retry logic on test suite to avoid failing tests due to 429.

## 💥 Breaking Change

Error responses are now standardized: `response.errors` will always be an array of error objects, regardless of the error type.  
Previously, for a 429 error, you had to check `response.errors.status`.  
With this update, you can consistently iterate over `response.errors` for all error scenarios.