### PR TITLE
Reduce debug logging noise

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "useBlockStatements": "error"
+      }
     }
   },
   "javascript": {

--- a/examples/bun/blog-1.ts
+++ b/examples/bun/blog-1.ts
@@ -28,7 +28,7 @@ const salesChannel = makeSalesChannel(
   {
     clientId: "<your_client_id>",
     scope: "<your_scope>",
-    debug: true, // useful to understand what happens behind the scene
+    debug: { logLevel: "info" }, // useful to understand what happens behind the scene
   },
   {
     storage: memoryStorage(),

--- a/examples/bun/blog-2.ts
+++ b/examples/bun/blog-2.ts
@@ -37,7 +37,7 @@ const integration = makeIntegration(
   {
     clientId: "<your_client_id>",
     clientSecret: "<your_client_secret>",
-    debug: true,
+    debug: { logLevel: "info" },
   },
   {
     storage: compositeStorage,

--- a/examples/nextjs/src/app/api-credentials/client/page.tsx
+++ b/examples/nextjs/src/app/api-credentials/client/page.tsx
@@ -1,9 +1,12 @@
 "use client"
 
-import DefaultTemplate from "@/components/DefaultTemplate"
-import { CommerceLayerAuthProvider, useCommerceLayerAuth } from "@/contexts/CommerceLayerAuthContext"
 import { getCoreApiBaseEndpoint, jwtDecode } from "@commercelayer/js-auth"
 import { useEffect, useMemo, useState } from "react"
+import DefaultTemplate from "@/components/DefaultTemplate"
+import {
+  CommerceLayerAuthProvider,
+  useCommerceLayerAuth,
+} from "@/contexts/CommerceLayerAuthContext"
 
 const scope = process.env.NEXT_PUBLIC_SCOPE as string
 
@@ -153,7 +156,12 @@ function CustomerOrders() {
     } else {
       setOrders(null)
     }
-  }, [authorization.accessToken, authorization.ownerType, authorization.ownerId, organizationSlug])
+  }, [
+    authorization.accessToken,
+    authorization.ownerType,
+    authorization.ownerId,
+    organizationSlug,
+  ])
 
   if (orders == null) {
     return null

--- a/examples/nextjs/src/app/utils/getServerSideToken.ts
+++ b/examples/nextjs/src/app/utils/getServerSideToken.ts
@@ -12,10 +12,15 @@ const salesChannel = makeSalesChannel(
   {
     clientId,
     scope,
-    debug: true,
+    debug: {
+      logLevel: "verbose",
+    },
   },
   {
     storage: createCompositeStorage({
+      debug: {
+        logLevel: "verbose",
+      },
       name: "serverCompositeStorage",
       storages: [
         createStorage({
@@ -34,7 +39,9 @@ const salesChannel = makeSalesChannel(
   },
 )
 
-export async function getServerSideAuth(): Promise<ReturnType<typeof makeSalesChannel>> {
+export async function getServerSideAuth(): Promise<
+  ReturnType<typeof makeSalesChannel>
+> {
   "use server"
 
   return {

--- a/examples/nextjs/src/contexts/CommerceLayerAuthContext.tsx
+++ b/examples/nextjs/src/contexts/CommerceLayerAuthContext.tsx
@@ -5,7 +5,7 @@ import {
   authenticate,
   makeSalesChannel,
 } from "@commercelayer/js-auth"
-import cookies from 'js-cookie'
+import cookies from "js-cookie"
 import {
   createContext,
   type ReactNode,
@@ -22,11 +22,14 @@ type AuthState = {
   accessToken?: string
   ownerType?: "customer" | "guest"
   ownerId?: string
-  errors?: Extract<AuthenticateReturn<'password'>, { errors?: unknown }>['errors']
+  errors?: Extract<
+    AuthenticateReturn<"password">,
+    { errors?: unknown }
+  >["errors"]
 }
 
 interface CommerceLayerAuthContextType extends AuthState {
-  login: ( email: string, password: string ) => Promise<void>
+  login: (email: string, password: string) => Promise<void>
   logout: () => Promise<void>
 }
 
@@ -46,7 +49,10 @@ export function useCommerceLayerAuth() {
 export function CommerceLayerAuthProvider({
   children,
   scope,
-}: { children: ReactNode; scope: string }) {
+}: {
+  children: ReactNode
+  scope: string
+}) {
   const [salesChannel, setSalesChannel] =
     useState<ReturnType<typeof makeSalesChannel>>()
 
@@ -58,7 +64,9 @@ export function CommerceLayerAuthProvider({
         {
           clientId,
           scope,
-          debug: true,
+          debug: {
+            logLevel: "verbose",
+          },
         },
         {
           storage: createStorage({
@@ -111,7 +119,10 @@ export function CommerceLayerAuthProvider({
       setAuth({
         accessToken: authorization.accessToken,
         ownerType: authorization.ownerType,
-        ownerId: authorization.ownerType === 'customer' ? authorization.ownerId : undefined,
+        ownerId:
+          authorization.ownerType === "customer"
+            ? authorization.ownerId
+            : undefined,
         errors: authorization.errors,
       })
     },
@@ -132,10 +143,7 @@ export function CommerceLayerAuthProvider({
     void salesChannel?.getAuthorization().then((auth) => {
       setAuth({
         ownerType: auth.ownerType,
-        ownerId:
-          auth.ownerType === "customer"
-            ? auth.ownerId
-            : undefined,
+        ownerId: auth.ownerType === "customer" ? auth.ownerId : undefined,
         accessToken: auth.accessToken,
         errors: auth.errors,
       })

--- a/examples/nextjs/src/proxies/withCommerceLayer.ts
+++ b/examples/nextjs/src/proxies/withCommerceLayer.ts
@@ -47,7 +47,9 @@ export const withCommerceLayer: WithProxy = (
         {
           clientId,
           scope,
-          debug: true,
+          debug: {
+            logLevel: "verbose",
+          },
         },
         {
           storage: createStorage({

--- a/packages/js-auth/README.md
+++ b/packages/js-auth/README.md
@@ -175,7 +175,9 @@ const salesChannel = makeSalesChannel(
   {
     clientId: "<your_client_id>",
     scope: "market:code:europe",
-    debug: true,
+    debug: {
+      logLevel: "info"
+    },
   },
   {
     storage: memoryStorage(),
@@ -249,19 +251,32 @@ flowchart TB
 
 You can enable debugging and assign custom names to your storage instances for better visibility into token operations:
 
-- **`debug`** — When set to `true`, logs detailed information about token operations (creation, retrieval, refresh, etc.).
+- **`debug`** — Accepts a `DebugConfig` object with two options:
+  - `logLevel: "info"` — logs meaningful events only: cache misses, token refreshes, authorizations stored/removed, and errors. Routine cache hits are silent, so setups that call `getAuthorization()` on every API request don't flood the logs.
+  - `logLevel: "verbose"` — also logs steady-state operations (every storage read and cache hit).
+  - `maskToken` — whether to mask access tokens and refresh tokens in the log output (e.g. `eyJh...A9Xz`). Defaults to `true`. Set to `false` to see full tokens, e.g. for inspecting them at [jwt.io](https://jwt.io).
 - **`name`** — A custom identifier for your storage instance, useful when using multiple storages or composite storage configurations. The `name` is an attribute of the storage itself (as shown in the [`memoryStorage` example above](#storage-strategy)).
+
+The `createCompositeStorage` helper accepts its own `debug` option, following the same rule: a hit on the first (fastest) storage is steady state, while falling back to a slower storage is a meaningful event worth logging.
+
+> [!WARNING]
+> When `maskToken` is set to `false`, full access tokens and refresh tokens are logged to the console. Intended for local development only — in serverless/edge environments, logs may be forwarded to external log aggregation services.
 
 ```diff
  const salesChannel = makeSalesChannel(
    {
      clientId: "<your_client_id>",
      scope: "market:code:europe",
-+    debug: true,
++    debug: {
++      logLevel: "info"
++    },
    },
    {
      storage: {
 +      name: "storage-name",
++      debug: {
++        logLevel: "info"
++      },
        async getItem(key) {
          // implementation
        },
@@ -499,7 +514,9 @@ const integration = makeIntegration(
   {
     clientId: "<your_client_id>",
     clientSecret: "<your_client_secret>",
-    debug: true,
+    debug: {
+      logLevel: "info"
+    },
   },
   {
     storage: compositeStorage,

--- a/packages/js-auth/src/apiCredentials/apiCredentials.debug.spec.ts
+++ b/packages/js-auth/src/apiCredentials/apiCredentials.debug.spec.ts
@@ -1,0 +1,249 @@
+import createFetchMock from "vitest-fetch-mock"
+import {
+  createCompositeStorage,
+  makeSalesChannel,
+  type Storage,
+  type StorageValue,
+} from "./index.js"
+
+const fetchMocker = createFetchMock(vi)
+
+const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {})
+
+const clientId = "a-client-id"
+const scope = "market:all"
+
+beforeEach(() => {
+  consoleLog.mockClear()
+})
+
+afterEach(() => {
+  // changes default behavior of fetchMock to use the real 'fetch' implementation and not mock responses
+  fetchMocker.dontMock()
+})
+
+afterAll(() => {
+  consoleLog.mockRestore()
+})
+
+describe("makeSalesChannel — debug logging", () => {
+  it("should not log anything when debug is not enabled", async () => {
+    const salesChannel = makeSalesChannel(
+      { clientId, scope },
+      { storage: makeStorageWithValidGuestToken() },
+    )
+
+    await salesChannel.getAuthorization()
+
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+
+  it("should not log anything on a cache hit when debug is `'info'`", async () => {
+    const salesChannel = makeSalesChannel(
+      { clientId, scope, debug: { logLevel: "info" } },
+      { storage: makeStorageWithValidGuestToken() },
+    )
+
+    await salesChannel.getAuthorization()
+    await salesChannel.getAuthorization()
+
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+
+  it("should log the cache hit when debug is `verbose`", async () => {
+    const salesChannel = makeSalesChannel(
+      { clientId, scope, debug: { logLevel: "verbose" } },
+      { storage: makeStorageWithValidGuestToken() },
+    )
+
+    await salesChannel.getAuthorization()
+
+    expect(loggedText()).toContain("Checking for customer key:")
+    expect(loggedText()).toContain('Found "guest" authorization in storage')
+  })
+
+  it("should log the transition when a new guest token is requested (cache miss)", async () => {
+    const accessToken = makeToken({
+      iat: nowInSeconds(),
+      exp: nowInSeconds() + 7200,
+    })
+
+    fetchMocker.enableMocks()
+    fetchMocker.doMockOnce(() => ({
+      body: JSON.stringify({
+        access_token: accessToken,
+        token_type: "bearer",
+        expires_in: 7200,
+        scope,
+        created_at: nowInSeconds(),
+      }),
+    }))
+
+    const salesChannel = makeSalesChannel(
+      { clientId, scope, debug: { logLevel: "info", maskToken: false } },
+      { storage: makeMemoryStorage("memory") },
+    )
+
+    await salesChannel.getAuthorization()
+
+    expect(loggedText()).toContain(
+      "No valid authorization found, requesting a new guest token",
+    )
+    expect(loggedText()).toContain('Stored "guest" authorization to storage')
+
+    // steady-state operations are not logged at info level
+    expect(loggedText()).not.toContain("Checking for customer key:")
+    expect(loggedText()).not.toContain('Found "guest" authorization in storage')
+
+    // the full access token is visible when maskToken is false (e.g. for jwt.io)
+    expect(loggedText()).toContain(accessToken)
+  })
+
+  it("should log the transition when an expired customer authorization is removed", async () => {
+    const storage = makeStorageWithValidGuestToken()
+    const expiredCustomerToken = makeToken({
+      iat: nowInSeconds() - 200,
+      exp: nowInSeconds() - 10,
+      owner: { id: "cust_123", type: "Customer" },
+    })
+
+    await storage.setItem(`cl_customer-${clientId}-${scope}`, {
+      accessToken: expiredCustomerToken,
+      scope,
+    })
+
+    const salesChannel = makeSalesChannel(
+      { clientId, scope, debug: { logLevel: "info" } },
+      { storage },
+    )
+
+    const authorization = await salesChannel.getAuthorization()
+
+    expect(authorization.ownerType).toEqual("guest")
+    expect(loggedText()).toContain("Customer authorization expired")
+    expect(loggedText()).toContain("removing stale authorization")
+  })
+
+  it("should log the transition when an authorization is removed", async () => {
+    const salesChannel = makeSalesChannel(
+      { clientId, scope, debug: { logLevel: "info" } },
+      { storage: makeStorageWithValidGuestToken() },
+    )
+
+    await salesChannel.removeAuthorization("guest")
+
+    expect(loggedText()).toContain('Removed "guest" authorization with key:')
+  })
+})
+
+describe("createCompositeStorage — debug logging", () => {
+  it("should log the transition when a value is found in a fallback storage, and stay silent on faster-storage hits", async () => {
+    const fasterStorage = makeMemoryStorage("memory")
+    const slowerStorage = makeMemoryStorage("redis")
+
+    const value: StorageValue = { accessToken: "an-access-token", scope }
+    await slowerStorage.setItem("a-key", value)
+
+    const compositeStorage = createCompositeStorage({
+      storages: [fasterStorage, slowerStorage],
+      name: "composite-storage",
+      debug: { logLevel: "info" },
+    })
+
+    // fallback hit: found in "redis", backfilled to "memory"
+    await compositeStorage.getItem("a-key")
+
+    expect(loggedText()).toContain(
+      'Value for key "a-key" found in fallback storage "redis" after missing in [memory], backfilling faster storages',
+    )
+
+    consoleLog.mockClear()
+
+    // steady-state hit on the faster storage: silent
+    await compositeStorage.getItem("a-key")
+
+    expect(consoleLog).not.toHaveBeenCalled()
+
+    // total miss: silent when debug is `'info'`
+    await compositeStorage.getItem("another-key")
+
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+
+  it("should log steady-state hits and misses when debug is `verbose`", async () => {
+    const storage = makeMemoryStorage("memory")
+    await storage.setItem("a-key", { accessToken: "an-access-token", scope })
+
+    const compositeStorage = createCompositeStorage({
+      storages: [storage],
+      name: "composite-storage",
+      debug: { logLevel: "verbose" },
+    })
+
+    await compositeStorage.getItem("a-key")
+    await compositeStorage.getItem("another-key")
+
+    expect(loggedText()).toContain(
+      'Value for key "a-key" found in storage "memory"',
+    )
+    expect(loggedText()).toContain(
+      'Value for key "another-key" not found in any storage',
+    )
+  })
+})
+
+function loggedText(): string {
+  return consoleLog.mock.calls
+    .map((call) =>
+      call
+        .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+        .join(" "),
+    )
+    .join("\n")
+}
+
+function makeMemoryStorage(name: string): Storage {
+  const state = new Map<string, StorageValue>()
+
+  return {
+    name,
+    async getItem(key) {
+      return state.get(key) ?? null
+    },
+    async setItem(key, value) {
+      state.set(key, value)
+    },
+    async removeItem(key) {
+      state.delete(key)
+    },
+  }
+}
+
+function makeStorageWithValidGuestToken(): Storage {
+  const storage = makeMemoryStorage("memory")
+
+  void storage.setItem(`cl_guest-${clientId}-${scope}`, {
+    accessToken: makeToken({
+      iat: nowInSeconds() - 200,
+      exp: nowInSeconds() + 3600,
+    }),
+    scope,
+  })
+
+  return storage
+}
+
+function nowInSeconds(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+function makeToken(payload: Record<string, unknown>): string {
+  const header = { alg: "HS256", typ: "JWT", kid: "test-key" }
+  const encodedHeader = Buffer.from(JSON.stringify(header), "binary").toString(
+    "base64url",
+  )
+  const encodedPayload = Buffer.from(JSON.stringify(payload), "utf-8").toString(
+    "base64url",
+  )
+  return `${encodedHeader}.${encodedPayload}.signature`
+}

--- a/packages/js-auth/src/apiCredentials/apiCredentials.ts
+++ b/packages/js-auth/src/apiCredentials/apiCredentials.ts
@@ -1,6 +1,7 @@
 import { authenticate } from "../authenticate.js"
 import { jwtDecode } from "../jwtDecode.js"
 import { hasOwner } from "../utils/hasOwner.js"
+import { createDebugLog } from "./debugLog.js"
 import { dedupConcurrentCalls } from "./dedupConcurrentCalls.js"
 import type { StorageValue, StoreOptions } from "./storage.js"
 import type {
@@ -77,18 +78,10 @@ export function makeAuth(
 
   const store = enhanceStoreOptions(_store)
 
-  function log(
-    storageName: string | undefined,
-    message: string,
-    ...args: unknown[]
-  ) {
-    if (authOptions.debug === true) {
-      console.log(
-        `[CommerceLayer • auth.js] [${logPrefix}]${storageName != null ? ` [${storageName}]` : ""} ${message}`,
-        ...args,
-      )
-    }
-  }
+  const log = createDebugLog({
+    debug: authOptions.debug,
+    logPrefix,
+  })
 
   const getStorageKey =
     store.getKey ??
@@ -125,7 +118,7 @@ export function makeAuth(
 
         const storage = store.customerStorage ?? store.storage
 
-        log(storage.name, "Checking for customer key:", customerKey)
+        log("verbose", storage.name, "Checking for customer key:", customerKey)
 
         const storedValue = await storage.getItem(customerKey)
         const customerAuthorization = toAuthorization(storedValue)
@@ -133,6 +126,7 @@ export function makeAuth(
         if (customerAuthorization?.ownerType === "customer") {
           if (customerAuthorization.expiresIn >= expirationThreshold) {
             log(
+              "verbose",
               storedValue?.storageName,
               'Found "customer" authorization in storage',
               customerAuthorization,
@@ -142,6 +136,7 @@ export function makeAuth(
           }
 
           log(
+            "info",
             storedValue?.storageName,
             "Customer authorization expired",
             customerAuthorization,
@@ -160,6 +155,7 @@ export function makeAuth(
             })
 
             log(
+              "info",
               storedValue?.storageName,
               "Refreshed customer authorization",
               authorization,
@@ -169,12 +165,14 @@ export function makeAuth(
           }
 
           log(
+            "info",
             storedValue?.storageName,
             "Customer authorization expired and has no refresh token, removing stale authorization",
           )
 
           await storage.removeItem(customerKey).catch((error) => {
             log(
+              "info",
               storedValue?.storageName,
               "Unable to remove stale customer authorization",
               error,
@@ -194,7 +192,7 @@ export function makeAuth(
 
       const storage = store.storage
 
-      log(storage.name, "Checking for guest key:", guestKey)
+      log("verbose", storage.name, "Checking for guest key:", guestKey)
 
       const storedValue = await storage.getItem(guestKey)
       const guestAuthorization = toAuthorization(storedValue)
@@ -204,6 +202,7 @@ export function makeAuth(
         guestAuthorization.expiresIn >= expirationThreshold
       ) {
         log(
+          "verbose",
           storedValue?.storageName,
           'Found "guest" authorization in storage',
           guestAuthorization,
@@ -215,6 +214,7 @@ export function makeAuth(
       // requesting a new token
 
       log(
+        "info",
         storage.name,
         "No valid authorization found, requesting a new guest token",
       )
@@ -232,7 +232,7 @@ export function makeAuth(
 
       return authorization
     } catch (error) {
-      log(undefined, "Error getting the authorization.", error)
+      log("info", undefined, "Error getting the authorization.", error)
       throw error
     }
   }
@@ -260,6 +260,7 @@ export function makeAuth(
         : store.storage
 
     log(
+      "verbose",
       storage.name,
       `Storing "${authorization.ownerType}" authorization with key:`,
       key,
@@ -268,6 +269,7 @@ export function makeAuth(
     await storage.setItem(key, value)
 
     log(
+      "info",
       storage.name,
       `Stored "${authorization.ownerType}" authorization to storage`,
       authorization,
@@ -291,7 +293,7 @@ export function makeAuth(
 
     await storage.removeItem(key)
 
-    log(storage.name, `Removed "${type}" authorization with key:`, key)
+    log("info", storage.name, `Removed "${type}" authorization with key:`, key)
   }
 
   return {

--- a/packages/js-auth/src/apiCredentials/debugLog.spec.ts
+++ b/packages/js-auth/src/apiCredentials/debugLog.spec.ts
@@ -1,0 +1,150 @@
+import { createDebugLog } from "./debugLog.js"
+
+const token = "eyJhbGciOiJSUzUxMiJ9.payload.signature"
+
+describe("createDebugLog", () => {
+  const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {})
+
+  beforeEach(() => {
+    consoleLog.mockClear()
+  })
+
+  afterAll(() => {
+    consoleLog.mockRestore()
+  })
+
+  it("should not log anything when debug is not defined", () => {
+    const log = createDebugLog({ debug: undefined, logPrefix: "sales_channel" })
+
+    log("info", "memory", "an event")
+    log("verbose", "memory", "a steady-state operation")
+
+    expect(consoleLog).not.toHaveBeenCalled()
+  })
+
+  it("should log info events only when debug is `{ logLevel: 'info' }`", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info" },
+      logPrefix: "sales_channel",
+    })
+    const authorization = {
+      accessToken: token,
+      refreshToken: "refresh-token",
+      scope: "market:all",
+    }
+
+    log("info", "memory", "an event", authorization)
+    log("verbose", "memory", "a steady-state operation")
+
+    expect(consoleLog).toHaveBeenCalledTimes(1)
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[CommerceLayer • auth.js] [sales_channel] [memory] an event",
+      {
+        accessToken: "eyJh...ture",
+        refreshToken: "refr...oken",
+        scope: "market:all",
+      },
+    )
+  })
+
+  it("should log everything when debug is `{ logLevel: 'verbose' }`", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "verbose" },
+      logPrefix: "integration",
+    })
+
+    log("info", "memory", "an event")
+    log("verbose", undefined, "a steady-state operation")
+
+    expect(consoleLog).toHaveBeenCalledTimes(2)
+    expect(consoleLog).toHaveBeenNthCalledWith(
+      1,
+      "[CommerceLayer • auth.js] [integration] [memory] an event",
+    )
+    expect(consoleLog).toHaveBeenNthCalledWith(
+      2,
+      "[CommerceLayer • auth.js] [integration] a steady-state operation",
+    )
+  })
+
+  it("should mask tokens by default", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info" },
+      logPrefix: "sales_channel",
+    })
+    const authorization = {
+      accessToken: token,
+      refreshToken: "refresh-token",
+      scope: "market:all",
+    }
+
+    log("info", "memory", "Stored authorization", authorization)
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[CommerceLayer • auth.js] [sales_channel] [memory] Stored authorization",
+      {
+        accessToken: "eyJh...ture",
+        refreshToken: "refr...oken",
+        scope: "market:all",
+      },
+    )
+  })
+
+  it("should pass tokens through when maskToken is `false`", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info", maskToken: false },
+      logPrefix: "sales_channel",
+    })
+    const authorization = { accessToken: token, scope: "market:all" }
+
+    log("info", "memory", "Stored authorization", authorization)
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[CommerceLayer • auth.js] [sales_channel] [memory] Stored authorization",
+      authorization,
+    )
+  })
+
+  it("should pass through values that are too short to be a JWT", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info" },
+      logPrefix: "sales_channel",
+    })
+
+    log("info", "memory", "Stored authorization", {
+      accessToken: "short",
+      scope: "market:all",
+    })
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[CommerceLayer • auth.js] [sales_channel] [memory] Stored authorization",
+      { accessToken: "short", scope: "market:all" },
+    )
+  })
+
+  it("should not mutate the original object when redacting", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info" },
+      logPrefix: "sales_channel",
+    })
+    const authorization = { accessToken: token, scope: "market:all" }
+
+    log("info", "memory", "Stored authorization", authorization)
+
+    expect(authorization.accessToken).toBe(token)
+  })
+
+  it("should leave non-authorization arguments unchanged when redacting", () => {
+    const log = createDebugLog({
+      debug: { logLevel: "info" },
+      logPrefix: "sales_channel",
+    })
+
+    log("info", "memory", "Cache miss", "some-key")
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      "[CommerceLayer • auth.js] [sales_channel] [memory] Cache miss",
+      "some-key",
+    )
+  })
+})

--- a/packages/js-auth/src/apiCredentials/debugLog.ts
+++ b/packages/js-auth/src/apiCredentials/debugLog.ts
@@ -1,0 +1,91 @@
+/**
+ * The level of a debug log entry.
+ *
+ * - `"info"` — a meaningful event (cache miss, token refresh, authorization
+ *   stored/removed, errors). Emitted when logLevel is `"info"` or `"verbose"`.
+ * - `"verbose"` — a steady-state operation (storage read, cache hit).
+ *   Emitted only when logLevel is `"verbose"`.
+ */
+type DebugLogLevel = "info" | "verbose"
+
+/**
+ * Fine-grained debug configuration.
+ *
+ * Pass this as the `debug` option to `makeSalesChannel`, `makeIntegration`,
+ * or `createCompositeStorage`.
+ */
+export type DebugConfig = {
+  /**
+   * The log level.
+   *
+   * - `"info"` — logs meaningful events only (cache miss, token refresh,
+   *   authorization stored/removed, errors). Routine cache hits are not logged,
+   *   making it suitable for setups that call `getAuthorization()` on every API request.
+   * - `"verbose"` — also logs steady-state operations (every storage read and cache hit).
+   */
+  logLevel: DebugLogLevel
+  /**
+   * Whether to partially mask access tokens and refresh tokens in the log output
+   * (e.g. `eyJh...A9Xz`). Useful when logs are forwarded to external services
+   * (e.g. Datadog, Sentry).
+   *
+   * @default true
+   */
+  maskToken?: boolean
+}
+
+type DebugLog = (
+  level: DebugLogLevel,
+  storageName: string | undefined,
+  message: string,
+  ...args: unknown[]
+) => void
+
+function maskToken<T>(value: T): T | string {
+  if (typeof value !== "string" || value.length <= 8) {
+    return value
+  }
+
+  return `${value.slice(0, 4)}...${value.slice(-4)}`
+}
+
+function redactArgs(args: unknown[]): unknown[] {
+  return args.map((arg) => {
+    if (arg !== null && typeof arg === "object" && "accessToken" in arg) {
+      return {
+        ...arg,
+        accessToken: maskToken(arg.accessToken),
+        ...("refreshToken" in arg
+          ? { refreshToken: maskToken(arg.refreshToken) }
+          : {}),
+      }
+    }
+    return arg
+  })
+}
+
+/**
+ * Creates the debug logger used by `makeAuth` and `createCompositeStorage`.
+ */
+export function createDebugLog({
+  debug,
+  logPrefix,
+}: {
+  debug: DebugConfig | undefined
+  logPrefix: string
+}): DebugLog {
+  return (level, storageName, message, ...args) => {
+    if (debug == null) {
+      return
+    }
+
+    if (level === "verbose" && debug.logLevel !== "verbose") {
+      return
+    }
+
+    const prefix = `[CommerceLayer • auth.js] [${logPrefix}]${storageName != null ? ` [${storageName}]` : ""} ${message}`
+    const finalArgs = (debug.maskToken ?? true) ? redactArgs(args) : args
+
+    console.log(prefix, ...finalArgs)
+  }
+}

--- a/packages/js-auth/src/apiCredentials/index.ts
+++ b/packages/js-auth/src/apiCredentials/index.ts
@@ -10,6 +10,7 @@ import type {
   SetRequired,
 } from "./types.js"
 
+export type { DebugConfig } from "./debugLog.js"
 export {
   createCompositeStorage,
   type Storage,

--- a/packages/js-auth/src/apiCredentials/storage.ts
+++ b/packages/js-auth/src/apiCredentials/storage.ts
@@ -1,4 +1,5 @@
 import type { AuthenticateReturn } from "../types/index.js"
+import { createDebugLog, type DebugConfig } from "./debugLog.js"
 import type { ApiCredentialsAuthorization } from "./types.js"
 
 /**
@@ -14,7 +15,7 @@ import type { ApiCredentialsAuthorization } from "./types.js"
  *
  * When setting or removing an item, the operation is performed on all configured storages to ensure consistency.
  *
- * @param options - An object containing an array of storage instances to combine and optionally a name.
+ * @param options - An object containing an array of storage instances to combine and optionally a name and a debug option.
  * @returns A composite storage instance.
  *
  * @example
@@ -31,6 +32,14 @@ import type { ApiCredentialsAuthorization } from "./types.js"
 export function createCompositeStorage(options: {
   storages: Storage[]
   name?: string
+  /**
+   * Whether to enable debug mode.
+   *
+   * - `"info"` — logs meaningful events only: a value found in a fallback
+   *   storage (i.e. a cache miss on the faster storages, with backfill).
+   * - `"verbose"` — also logs steady-state operations (hits on the first storage and total misses).
+   */
+  debug?: DebugConfig
 }): Storage
 
 /**
@@ -43,26 +52,48 @@ export function createCompositeStorage(storages: Storage[]): Storage
 
 export function createCompositeStorage(
   // TODO: remember to remove the deprecated overload in the next major release
-  storagesOrOptions: Storage[] | { storages: Storage[]; name?: string },
+  storagesOrOptions:
+    | Storage[]
+    | { storages: Storage[]; name?: string; debug?: DebugConfig },
 ): Storage {
   // TODO: remember to remove the deprecated overload in the next major release
   const options = Array.isArray(storagesOrOptions)
     ? { storages: storagesOrOptions }
     : storagesOrOptions
 
+  const log = createDebugLog({
+    debug: options.debug,
+    logPrefix: "storage",
+  })
+
+  const compositeName = "name" in options ? options.name : undefined
+
   return {
-    name: options.name,
+    name: compositeName,
 
     async getItem(key: string) {
-      for (const storage of options.storages) {
+      for (const [index, storage] of options.storages.entries()) {
         const value = await storage.getItem(key)
 
         if (value !== null) {
-          for (const previousStorage of options.storages.slice(
-            0,
-            options.storages.indexOf(storage),
-          )) {
-            await previousStorage.setItem(key, value)
+          if (index > 0) {
+            const missedStorages = options.storages.slice(0, index)
+
+            log(
+              "info",
+              compositeName,
+              `Value for key "${key}" found in fallback storage "${storage.name ?? `#${index}`}" after missing in [${missedStorages.map((missed, missedIndex) => missed.name ?? `#${missedIndex}`).join(", ")}], backfilling faster storages`,
+            )
+
+            for (const previousStorage of missedStorages) {
+              await previousStorage.setItem(key, value)
+            }
+          } else {
+            log(
+              "verbose",
+              compositeName,
+              `Value for key "${key}" found in storage "${storage.name ?? `#${index}`}"`,
+            )
           }
 
           return {
@@ -71,6 +102,13 @@ export function createCompositeStorage(
           }
         }
       }
+
+      log(
+        "verbose",
+        compositeName,
+        `Value for key "${key}" not found in any storage`,
+      )
+
       return null
     },
 

--- a/packages/js-auth/src/apiCredentials/types.ts
+++ b/packages/js-auth/src/apiCredentials/types.ts
@@ -1,5 +1,6 @@
 import type { TBaseReturn } from "../types/base.js"
 import type { AuthenticateOptions } from "../types/index.js"
+import type { DebugConfig } from "./debugLog.js"
 
 export type ApiCredentialsAuthorization = TBaseReturn &
   (
@@ -32,19 +33,21 @@ export type AuthOptions = AuthenticateOptions<"client_credentials"> & {
   /**
    * Whether to enable debug mode.
    *
-   * ⚠️ **WARNING**: When enabled, full authorization objects (including access tokens
-   * and refresh tokens) will be logged to the console. This is intended for local
-   * development only.
+   * - `true` — shortcut for `{ logLevel: "info" }`: logs meaningful events only
+   *   (cache misses, token refreshes, authorizations stored/removed, errors).
+   *   Tokens are redacted by default.
+   * - `DebugConfig` — fine-grained control:
+   *   - `logLevel: "info"` — meaningful events only.
+   *   - `logLevel: "verbose"` — also logs steady-state operations (every storage read and cache hit).
+   *   - `maskToken` — whether to redact tokens (default `true`). Set to `false` to see
+   *     full tokens, e.g. for inspecting them at [jwt.io](https://jwt.io).
    *
    * **Security considerations**:
-   * - Tokens will be visible in browser DevTools or terminal output
    * - In serverless/edge environments (Cloudflare Workers, Vercel Functions), logs may be
    *   forwarded to external log aggregation services (e.g., Datadog, Sentry, Cloudflare Analytics)
-   * - Avoid enabling debug mode in production or shared environments
-   *
-   * @default false
+   * - Avoid setting `maskToken: false` in production or shared environments
    */
-  debug?: boolean
+  debug?: DebugConfig
 
   // dedupConcurrentCalls?: (
   //   fn: (...args: any[]) => any,


### PR DESCRIPTION
Related to #134

## What I did

Replaces `debug?: boolean` with `debug?: DebugConfig` to reduce log noise and improve security.

The `debug` option is available on `makeSalesChannel`, `makeIntegration`, and `createCompositeStorage`.

```ts
type DebugConfig = {
  logLevel: "info" | "verbose"
  maskToken?: boolean // default: true
}
```

- `logLevel: "info"`: logs meaningful events only (cache miss, token refresh, stored/removed, errors). Suitable for setups that call `getAuthorization()` on every API request.
- `logLevel: "verbose"`: also logs steady-state operations (every storage read and cache hit).
- `maskToken`: masks tokens in the log output (e.g. `eyJh...A9Xz`). Defaults to `true`. Set to `false` to see full tokens.

## Breaking changes

The `debug` option now requires an object instead of a boolean. This makes the API explicit about what gets logged and whether tokens are masked. It also defaults to masking tokens, which is safer for setups where logs are forwarded to external services.

Migrating is straightforward

```diff
- debug: true
+ debug: { logLevel: "verbose", maskToken: false }
```

but we strongly suggest to keep `maskToken` set to `true`.

Remove any explicit `debug: false`. Omitting the option is equivalent.
