### PR TITLE
Remove deprecated `createCompositeStorage` array overload

### DIFF
--- a/packages/js-auth/src/apiCredentials/storage.ts
+++ b/packages/js-auth/src/apiCredentials/storage.ts
@@ -40,33 +40,13 @@ export function createCompositeStorage(options: {
    * - `"verbose"` — also logs steady-state operations (hits on the first storage and total misses).
    */
   debug?: DebugConfig
-}): Storage
-
-/**
- * Creates a composite storage that combines multiple storages.
- *
- * @deprecated Use `createCompositeStorage` with options object instead.
- */
-export function createCompositeStorage(storages: Storage[]): Storage
-// TODO: remember to remove the deprecated overload in the next major release
-
-export function createCompositeStorage(
-  // TODO: remember to remove the deprecated overload in the next major release
-  storagesOrOptions:
-    | Storage[]
-    | { storages: Storage[]; name?: string; debug?: DebugConfig },
-): Storage {
-  // TODO: remember to remove the deprecated overload in the next major release
-  const options = Array.isArray(storagesOrOptions)
-    ? { storages: storagesOrOptions }
-    : storagesOrOptions
-
+}): Storage {
   const log = createDebugLog({
     debug: options.debug,
     logPrefix: "storage",
   })
 
-  const compositeName = "name" in options ? options.name : undefined
+  const compositeName = options.name
 
   return {
     name: compositeName,


### PR DESCRIPTION
Related to #135

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Removed the deprecated `createCompositeStorage(storages: Storage[])` overload. Only the options-object form remains:

```ts
createCompositeStorage({ storages, name?, debug? })
```

## Breaking changes

`createCompositeStorage` no longer accepts a plain array of storages.

```diff
- createCompositeStorage([memoryStorage, redisStorage])
+ createCompositeStorage({ storages: [memoryStorage, redisStorage] })
```
